### PR TITLE
feat: 振り返り一覧・詳細表示 UI 実装

### DIFF
--- a/backend/src/main/java/com/myretro/controller/retrospective/CreateRetrospectiveController.java
+++ b/backend/src/main/java/com/myretro/controller/retrospective/CreateRetrospectiveController.java
@@ -9,6 +9,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -32,6 +33,7 @@ public class CreateRetrospectiveController {
      * @return 作成された振り返り（201 Created）
      */
     @PostMapping
+    @Transactional
     public ResponseEntity<RetrospectiveResponse> handle(
             @AuthenticationPrincipal Long userId,
             @Valid @RequestBody CreateRetrospectiveRequest request) {

--- a/backend/src/main/java/com/myretro/controller/retrospective/UpdateRetrospectiveController.java
+++ b/backend/src/main/java/com/myretro/controller/retrospective/UpdateRetrospectiveController.java
@@ -8,6 +8,7 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -33,6 +34,7 @@ public class UpdateRetrospectiveController {
      * @return 更新された振り返り（200 OK）
      */
     @PutMapping("/{id}")
+    @Transactional
     public ResponseEntity<RetrospectiveResponse> handle(
             @AuthenticationPrincipal Long userId,
             @PathVariable Long id,

--- a/backend/src/main/java/com/myretro/dto/retrospective/RetrospectiveResponse.java
+++ b/backend/src/main/java/com/myretro/dto/retrospective/RetrospectiveResponse.java
@@ -2,35 +2,56 @@ package com.myretro.dto.retrospective;
 
 import java.time.LocalDateTime;
 
+import com.myretro.entity.KptType;
 import com.myretro.entity.Retrospective;
 
 /**
  * 振り返りレスポンス DTO（一覧・作成・更新時に使用）。
  *
- * @param id          振り返り ID
- * @param title       タイトル
- * @param description 説明
- * @param createdAt   作成日時
- * @param updatedAt   更新日時
+ * @param id           振り返り ID
+ * @param title        タイトル
+ * @param description  説明
+ * @param keepCount    Keep アイテム数
+ * @param problemCount Problem アイテム数
+ * @param tryCount     Try アイテム数
+ * @param createdAt    作成日時
+ * @param updatedAt    更新日時
  */
 public record RetrospectiveResponse(
         Long id,
         String title,
         String description,
+        long keepCount,
+        long problemCount,
+        long tryCount,
         LocalDateTime createdAt,
         LocalDateTime updatedAt) {
 
     /**
      * エンティティからレスポンス DTO を生成する。
+     * KPT アイテムのカウントを種別ごとに集計する。
      *
      * @param retrospective 変換元の振り返りエンティティ
      * @return レスポンス DTO
      */
     public static RetrospectiveResponse from(Retrospective retrospective) {
+        long keepCount = retrospective.getKptItems().stream()
+                .filter(item -> item.getType() == KptType.KEEP)
+                .count();
+        long problemCount = retrospective.getKptItems().stream()
+                .filter(item -> item.getType() == KptType.PROBLEM)
+                .count();
+        long tryCount = retrospective.getKptItems().stream()
+                .filter(item -> item.getType() == KptType.TRY)
+                .count();
+
         return new RetrospectiveResponse(
                 retrospective.getId(),
                 retrospective.getTitle(),
                 retrospective.getDescription(),
+                keepCount,
+                problemCount,
+                tryCount,
                 retrospective.getCreatedAt(),
                 retrospective.getUpdatedAt());
     }

--- a/backend/src/main/java/com/myretro/repository/RetrospectiveRepository.java
+++ b/backend/src/main/java/com/myretro/repository/RetrospectiveRepository.java
@@ -5,6 +5,8 @@ import java.util.Optional;
 
 import com.myretro.entity.Retrospective;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 /**
  * 振り返りセッションのリポジトリ。
@@ -28,4 +30,13 @@ public interface RetrospectiveRepository extends JpaRepository<Retrospective, Lo
      * @return 振り返りのリスト
      */
     List<Retrospective> findByUserIdOrderByCreatedAtDesc(Long userId);
+
+    /**
+     * 指定ユーザーの振り返り一覧を KPT アイテムとともに取得する（作成日時の降順）。
+     *
+     * @param userId ユーザー ID
+     * @return 振り返りのリスト（KPT アイテムを含む）
+     */
+    @Query("SELECT DISTINCT r FROM Retrospective r LEFT JOIN FETCH r.kptItems WHERE r.user.id = :userId ORDER BY r.createdAt DESC")
+    List<Retrospective> findByUserIdWithKptItemsOrderByCreatedAtDesc(@Param("userId") Long userId);
 }

--- a/backend/src/main/java/com/myretro/service/retrospective/ListRetrospectivesService.java
+++ b/backend/src/main/java/com/myretro/service/retrospective/ListRetrospectivesService.java
@@ -25,6 +25,6 @@ public class ListRetrospectivesService {
      */
     @Transactional(readOnly = true)
     public List<Retrospective> list(Long userId) {
-        return retrospectiveRepository.findByUserIdOrderByCreatedAtDesc(userId);
+        return retrospectiveRepository.findByUserIdWithKptItemsOrderByCreatedAtDesc(userId);
     }
 }

--- a/backend/src/test/java/com/myretro/controller/retrospective/ListRetrospectivesControllerTest.java
+++ b/backend/src/test/java/com/myretro/controller/retrospective/ListRetrospectivesControllerTest.java
@@ -1,8 +1,12 @@
 package com.myretro.controller.retrospective;
 
+import com.myretro.entity.KptItem;
+import com.myretro.entity.KptType;
 import com.myretro.entity.Retrospective;
 import com.myretro.entity.User;
+import com.myretro.repository.KptItemRepository;
 import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
 
 import static org.hamcrest.Matchers.hasSize;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
@@ -10,6 +14,9 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 class ListRetrospectivesControllerTest extends BaseRetrospectiveControllerTest {
+
+    @Autowired
+    private KptItemRepository kptItemRepository;
 
     @Test
     void 振り返り一覧取得で200が返る() throws Exception {
@@ -29,5 +36,26 @@ class ListRetrospectivesControllerTest extends BaseRetrospectiveControllerTest {
                         .header("Authorization", "Bearer " + accessToken))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$", hasSize(0)));
+    }
+
+    @Test
+    void 振り返り一覧にKPTカウントが含まれる() throws Exception {
+        User user = userRepository.findByEmail("test@example.com").orElseThrow();
+        Retrospective retro = retrospectiveRepository.save(new Retrospective(user, "Sprint 1", "desc1"));
+
+        kptItemRepository.save(new KptItem(retro, KptType.KEEP, "keep1", 0));
+        kptItemRepository.save(new KptItem(retro, KptType.KEEP, "keep2", 1));
+        kptItemRepository.save(new KptItem(retro, KptType.PROBLEM, "problem1", 0));
+        kptItemRepository.save(new KptItem(retro, KptType.TRY, "try1", 0));
+        kptItemRepository.save(new KptItem(retro, KptType.TRY, "try2", 1));
+        kptItemRepository.save(new KptItem(retro, KptType.TRY, "try3", 2));
+
+        mockMvc.perform(get("/api/retrospectives")
+                        .header("Authorization", "Bearer " + accessToken))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$", hasSize(1)))
+                .andExpect(jsonPath("$[0].keepCount").value(2))
+                .andExpect(jsonPath("$[0].problemCount").value(1))
+                .andExpect(jsonPath("$[0].tryCount").value(3));
     }
 }

--- a/backend/src/test/java/com/myretro/service/retrospective/ListRetrospectivesServiceTest.java
+++ b/backend/src/test/java/com/myretro/service/retrospective/ListRetrospectivesServiceTest.java
@@ -29,7 +29,7 @@ class ListRetrospectivesServiceTest {
         List<Retrospective> retrospectives = List.of(
                 new Retrospective(user, "Sprint 2", null),
                 new Retrospective(user, "Sprint 1", "First sprint"));
-        given(retrospectiveRepository.findByUserIdOrderByCreatedAtDesc(1L)).willReturn(retrospectives);
+        given(retrospectiveRepository.findByUserIdWithKptItemsOrderByCreatedAtDesc(1L)).willReturn(retrospectives);
 
         List<Retrospective> result = listRetrospectivesService.list(1L);
 
@@ -39,7 +39,7 @@ class ListRetrospectivesServiceTest {
 
     @Test
     void 振り返りがない場合は空リストを返す() {
-        given(retrospectiveRepository.findByUserIdOrderByCreatedAtDesc(1L)).willReturn(List.of());
+        given(retrospectiveRepository.findByUserIdWithKptItemsOrderByCreatedAtDesc(1L)).willReturn(List.of());
 
         List<Retrospective> result = listRetrospectivesService.list(1L);
 

--- a/frontend/src/components/kpt-card.tsx
+++ b/frontend/src/components/kpt-card.tsx
@@ -6,11 +6,12 @@ import type { KptItem } from "@/types/retrospective";
 
 interface KptCardProps {
   item: KptItem;
-  onUpdate: (content: string) => Promise<void>;
-  onDelete: () => Promise<void>;
+  readOnly?: boolean;
+  onUpdate?: (content: string) => Promise<void>;
+  onDelete?: () => Promise<void>;
 }
 
-export function KptCard({ item, onUpdate, onDelete }: KptCardProps) {
+export function KptCard({ item, readOnly, onUpdate, onDelete }: KptCardProps) {
   const [isEditing, setIsEditing] = useState(false);
   const [editContent, setEditContent] = useState(item.content);
   const [isDeleting, setIsDeleting] = useState(false);
@@ -26,7 +27,7 @@ export function KptCard({ item, onUpdate, onDelete }: KptCardProps) {
   const handleSave = async () => {
     const trimmed = editContent.trim();
     if (trimmed && trimmed !== item.content) {
-      await onUpdate(trimmed);
+      await onUpdate?.(trimmed);
     }
     setIsEditing(false);
   };
@@ -49,7 +50,7 @@ export function KptCard({ item, onUpdate, onDelete }: KptCardProps) {
   const handleDelete = async () => {
     setIsDeleting(true);
     try {
-      await onDelete();
+      await onDelete?.();
     } catch {
       setIsDeleting(false);
     }
@@ -84,6 +85,14 @@ export function KptCard({ item, onUpdate, onDelete }: KptCardProps) {
             保存
           </Button>
         </div>
+      </div>
+    );
+  }
+
+  if (readOnly) {
+    return (
+      <div className="rounded-md border bg-white p-3 shadow-sm">
+        <p className="whitespace-pre-wrap text-sm">{item.content}</p>
       </div>
     );
   }

--- a/frontend/src/components/kpt-column.tsx
+++ b/frontend/src/components/kpt-column.tsx
@@ -87,7 +87,11 @@ export function KptColumn({
             key={item.id}
             item={item}
             readOnly={readOnly}
-            onUpdate={onUpdateItem ? (content) => onUpdateItem(item.id, content) : undefined}
+            onUpdate={
+              onUpdateItem
+                ? (content) => onUpdateItem(item.id, content)
+                : undefined
+            }
             onDelete={onDeleteItem ? () => onDeleteItem(item.id) : undefined}
           />
         ))}

--- a/frontend/src/components/kpt-column.tsx
+++ b/frontend/src/components/kpt-column.tsx
@@ -29,14 +29,16 @@ const COLUMN_CONFIG: Record<
 interface KptColumnProps {
   type: KptType;
   items: KptItem[];
-  onAddItem: (content: string) => Promise<void>;
-  onUpdateItem: (itemId: number, content: string) => Promise<void>;
-  onDeleteItem: (itemId: number) => Promise<void>;
+  readOnly?: boolean;
+  onAddItem?: (content: string) => Promise<void>;
+  onUpdateItem?: (itemId: number, content: string) => Promise<void>;
+  onDeleteItem?: (itemId: number) => Promise<void>;
 }
 
 export function KptColumn({
   type,
   items,
+  readOnly,
   onAddItem,
   onUpdateItem,
   onDeleteItem,
@@ -51,7 +53,7 @@ export function KptColumn({
     if (!trimmed) return;
     setIsSubmitting(true);
     try {
-      await onAddItem(trimmed);
+      await onAddItem?.(trimmed);
       setNewContent("");
       setIsAdding(false);
     } finally {
@@ -84,13 +86,14 @@ export function KptColumn({
           <KptCard
             key={item.id}
             item={item}
-            onUpdate={(content) => onUpdateItem(item.id, content)}
-            onDelete={() => onDeleteItem(item.id)}
+            readOnly={readOnly}
+            onUpdate={onUpdateItem ? (content) => onUpdateItem(item.id, content) : undefined}
+            onDelete={onDeleteItem ? () => onDeleteItem(item.id) : undefined}
           />
         ))}
       </div>
 
-      {isAdding ? (
+      {!readOnly && isAdding ? (
         <div className="mt-3">
           <Textarea
             value={newContent}
@@ -122,7 +125,7 @@ export function KptColumn({
             </Button>
           </div>
         </div>
-      ) : (
+      ) : !readOnly ? (
         <Button
           variant="ghost"
           className={`mt-3 w-full justify-start ${config.color}`}
@@ -131,7 +134,7 @@ export function KptColumn({
           <Plus className="mr-1 h-4 w-4" />
           カードを追加
         </Button>
-      )}
+      ) : null}
     </div>
   );
 }

--- a/frontend/src/components/ui/alert-dialog.tsx
+++ b/frontend/src/components/ui/alert-dialog.tsx
@@ -1,0 +1,194 @@
+import * as React from "react"
+import { AlertDialog as AlertDialogPrimitive } from "radix-ui"
+
+import { cn } from "@/lib/utils"
+import { Button } from "@/components/ui/button"
+
+function AlertDialog({
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Root>) {
+  return <AlertDialogPrimitive.Root data-slot="alert-dialog" {...props} />
+}
+
+function AlertDialogTrigger({
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Trigger>) {
+  return (
+    <AlertDialogPrimitive.Trigger data-slot="alert-dialog-trigger" {...props} />
+  )
+}
+
+function AlertDialogPortal({
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Portal>) {
+  return (
+    <AlertDialogPrimitive.Portal data-slot="alert-dialog-portal" {...props} />
+  )
+}
+
+function AlertDialogOverlay({
+  className,
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Overlay>) {
+  return (
+    <AlertDialogPrimitive.Overlay
+      data-slot="alert-dialog-overlay"
+      className={cn(
+        "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 fixed inset-0 z-50 bg-black/50",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function AlertDialogContent({
+  className,
+  size = "default",
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Content> & {
+  size?: "default" | "sm"
+}) {
+  return (
+    <AlertDialogPortal>
+      <AlertDialogOverlay />
+      <AlertDialogPrimitive.Content
+        data-slot="alert-dialog-content"
+        data-size={size}
+        className={cn(
+          "bg-background data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 group/alert-dialog-content fixed top-[50%] left-[50%] z-50 grid w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-4 rounded-lg border p-6 shadow-lg duration-200 data-[size=sm]:max-w-xs data-[size=default]:sm:max-w-lg",
+          className
+        )}
+        {...props}
+      />
+    </AlertDialogPortal>
+  )
+}
+
+function AlertDialogHeader({
+  className,
+  ...props
+}: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="alert-dialog-header"
+      className={cn(
+        "grid grid-rows-[auto_1fr] place-items-center gap-1.5 text-center has-data-[slot=alert-dialog-media]:grid-rows-[auto_auto_1fr] has-data-[slot=alert-dialog-media]:gap-x-6 sm:group-data-[size=default]/alert-dialog-content:place-items-start sm:group-data-[size=default]/alert-dialog-content:text-left sm:group-data-[size=default]/alert-dialog-content:has-data-[slot=alert-dialog-media]:grid-rows-[auto_1fr]",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function AlertDialogFooter({
+  className,
+  ...props
+}: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="alert-dialog-footer"
+      className={cn(
+        "flex flex-col-reverse gap-2 group-data-[size=sm]/alert-dialog-content:grid group-data-[size=sm]/alert-dialog-content:grid-cols-2 sm:flex-row sm:justify-end",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function AlertDialogTitle({
+  className,
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Title>) {
+  return (
+    <AlertDialogPrimitive.Title
+      data-slot="alert-dialog-title"
+      className={cn(
+        "text-lg font-semibold sm:group-data-[size=default]/alert-dialog-content:group-has-data-[slot=alert-dialog-media]/alert-dialog-content:col-start-2",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function AlertDialogDescription({
+  className,
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Description>) {
+  return (
+    <AlertDialogPrimitive.Description
+      data-slot="alert-dialog-description"
+      className={cn("text-muted-foreground text-sm", className)}
+      {...props}
+    />
+  )
+}
+
+function AlertDialogMedia({
+  className,
+  ...props
+}: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="alert-dialog-media"
+      className={cn(
+        "bg-muted mb-2 inline-flex size-16 items-center justify-center rounded-md sm:group-data-[size=default]/alert-dialog-content:row-span-2 *:[svg:not([class*='size-'])]:size-8",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function AlertDialogAction({
+  className,
+  variant = "default",
+  size = "default",
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Action> &
+  Pick<React.ComponentProps<typeof Button>, "variant" | "size">) {
+  return (
+    <Button variant={variant} size={size} asChild>
+      <AlertDialogPrimitive.Action
+        data-slot="alert-dialog-action"
+        className={cn(className)}
+        {...props}
+      />
+    </Button>
+  )
+}
+
+function AlertDialogCancel({
+  className,
+  variant = "outline",
+  size = "default",
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Cancel> &
+  Pick<React.ComponentProps<typeof Button>, "variant" | "size">) {
+  return (
+    <Button variant={variant} size={size} asChild>
+      <AlertDialogPrimitive.Cancel
+        data-slot="alert-dialog-cancel"
+        className={cn(className)}
+        {...props}
+      />
+    </Button>
+  )
+}
+
+export {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogMedia,
+  AlertDialogOverlay,
+  AlertDialogPortal,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+}

--- a/frontend/src/components/ui/alert-dialog.tsx
+++ b/frontend/src/components/ui/alert-dialog.tsx
@@ -1,13 +1,13 @@
-import * as React from "react"
-import { AlertDialog as AlertDialogPrimitive } from "radix-ui"
+import * as React from "react";
+import { AlertDialog as AlertDialogPrimitive } from "radix-ui";
 
-import { cn } from "@/lib/utils"
-import { Button } from "@/components/ui/button"
+import { cn } from "@/lib/utils";
+import { Button } from "@/components/ui/button";
 
 function AlertDialog({
   ...props
 }: React.ComponentProps<typeof AlertDialogPrimitive.Root>) {
-  return <AlertDialogPrimitive.Root data-slot="alert-dialog" {...props} />
+  return <AlertDialogPrimitive.Root data-slot="alert-dialog" {...props} />;
 }
 
 function AlertDialogTrigger({
@@ -15,7 +15,7 @@ function AlertDialogTrigger({
 }: React.ComponentProps<typeof AlertDialogPrimitive.Trigger>) {
   return (
     <AlertDialogPrimitive.Trigger data-slot="alert-dialog-trigger" {...props} />
-  )
+  );
 }
 
 function AlertDialogPortal({
@@ -23,7 +23,7 @@ function AlertDialogPortal({
 }: React.ComponentProps<typeof AlertDialogPrimitive.Portal>) {
   return (
     <AlertDialogPrimitive.Portal data-slot="alert-dialog-portal" {...props} />
-  )
+  );
 }
 
 function AlertDialogOverlay({
@@ -35,11 +35,11 @@ function AlertDialogOverlay({
       data-slot="alert-dialog-overlay"
       className={cn(
         "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 fixed inset-0 z-50 bg-black/50",
-        className
+        className,
       )}
       {...props}
     />
-  )
+  );
 }
 
 function AlertDialogContent({
@@ -47,7 +47,7 @@ function AlertDialogContent({
   size = "default",
   ...props
 }: React.ComponentProps<typeof AlertDialogPrimitive.Content> & {
-  size?: "default" | "sm"
+  size?: "default" | "sm";
 }) {
   return (
     <AlertDialogPortal>
@@ -57,12 +57,12 @@ function AlertDialogContent({
         data-size={size}
         className={cn(
           "bg-background data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 group/alert-dialog-content fixed top-[50%] left-[50%] z-50 grid w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-4 rounded-lg border p-6 shadow-lg duration-200 data-[size=sm]:max-w-xs data-[size=default]:sm:max-w-lg",
-          className
+          className,
         )}
         {...props}
       />
     </AlertDialogPortal>
-  )
+  );
 }
 
 function AlertDialogHeader({
@@ -74,11 +74,11 @@ function AlertDialogHeader({
       data-slot="alert-dialog-header"
       className={cn(
         "grid grid-rows-[auto_1fr] place-items-center gap-1.5 text-center has-data-[slot=alert-dialog-media]:grid-rows-[auto_auto_1fr] has-data-[slot=alert-dialog-media]:gap-x-6 sm:group-data-[size=default]/alert-dialog-content:place-items-start sm:group-data-[size=default]/alert-dialog-content:text-left sm:group-data-[size=default]/alert-dialog-content:has-data-[slot=alert-dialog-media]:grid-rows-[auto_1fr]",
-        className
+        className,
       )}
       {...props}
     />
-  )
+  );
 }
 
 function AlertDialogFooter({
@@ -90,11 +90,11 @@ function AlertDialogFooter({
       data-slot="alert-dialog-footer"
       className={cn(
         "flex flex-col-reverse gap-2 group-data-[size=sm]/alert-dialog-content:grid group-data-[size=sm]/alert-dialog-content:grid-cols-2 sm:flex-row sm:justify-end",
-        className
+        className,
       )}
       {...props}
     />
-  )
+  );
 }
 
 function AlertDialogTitle({
@@ -106,11 +106,11 @@ function AlertDialogTitle({
       data-slot="alert-dialog-title"
       className={cn(
         "text-lg font-semibold sm:group-data-[size=default]/alert-dialog-content:group-has-data-[slot=alert-dialog-media]/alert-dialog-content:col-start-2",
-        className
+        className,
       )}
       {...props}
     />
-  )
+  );
 }
 
 function AlertDialogDescription({
@@ -123,7 +123,7 @@ function AlertDialogDescription({
       className={cn("text-muted-foreground text-sm", className)}
       {...props}
     />
-  )
+  );
 }
 
 function AlertDialogMedia({
@@ -135,11 +135,11 @@ function AlertDialogMedia({
       data-slot="alert-dialog-media"
       className={cn(
         "bg-muted mb-2 inline-flex size-16 items-center justify-center rounded-md sm:group-data-[size=default]/alert-dialog-content:row-span-2 *:[svg:not([class*='size-'])]:size-8",
-        className
+        className,
       )}
       {...props}
     />
-  )
+  );
 }
 
 function AlertDialogAction({
@@ -157,7 +157,7 @@ function AlertDialogAction({
         {...props}
       />
     </Button>
-  )
+  );
 }
 
 function AlertDialogCancel({
@@ -175,7 +175,7 @@ function AlertDialogCancel({
         {...props}
       />
     </Button>
-  )
+  );
 }
 
 export {
@@ -191,4 +191,4 @@ export {
   AlertDialogPortal,
   AlertDialogTitle,
   AlertDialogTrigger,
-}
+};

--- a/frontend/src/components/ui/button.tsx
+++ b/frontend/src/components/ui/button.tsx
@@ -1,8 +1,8 @@
-import * as React from "react"
-import { cva, type VariantProps } from "class-variance-authority"
-import { Slot } from "radix-ui"
+import * as React from "react";
+import { cva, type VariantProps } from "class-variance-authority";
+import { Slot } from "radix-ui";
 
-import { cn } from "@/lib/utils"
+import { cn } from "@/lib/utils";
 
 const buttonVariants = cva(
   "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-all disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4 shrink-0 [&_svg]:shrink-0 outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive",
@@ -35,8 +35,8 @@ const buttonVariants = cva(
       variant: "default",
       size: "default",
     },
-  }
-)
+  },
+);
 
 function Button({
   className,
@@ -46,9 +46,9 @@ function Button({
   ...props
 }: React.ComponentProps<"button"> &
   VariantProps<typeof buttonVariants> & {
-    asChild?: boolean
+    asChild?: boolean;
   }) {
-  const Comp = asChild ? Slot.Root : "button"
+  const Comp = asChild ? Slot.Root : "button";
 
   return (
     <Comp
@@ -58,7 +58,7 @@ function Button({
       className={cn(buttonVariants({ variant, size, className }))}
       {...props}
     />
-  )
+  );
 }
 
-export { Button, buttonVariants }
+export { Button, buttonVariants };

--- a/frontend/src/components/ui/button.tsx
+++ b/frontend/src/components/ui/button.tsx
@@ -1,8 +1,8 @@
-import * as React from "react";
-import { cva, type VariantProps } from "class-variance-authority";
-import { Slot } from "radix-ui";
+import * as React from "react"
+import { cva, type VariantProps } from "class-variance-authority"
+import { Slot } from "radix-ui"
 
-import { cn } from "@/lib/utils";
+import { cn } from "@/lib/utils"
 
 const buttonVariants = cva(
   "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-all disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4 shrink-0 [&_svg]:shrink-0 outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive",
@@ -35,8 +35,8 @@ const buttonVariants = cva(
       variant: "default",
       size: "default",
     },
-  },
-);
+  }
+)
 
 function Button({
   className,
@@ -46,9 +46,9 @@ function Button({
   ...props
 }: React.ComponentProps<"button"> &
   VariantProps<typeof buttonVariants> & {
-    asChild?: boolean;
+    asChild?: boolean
   }) {
-  const Comp = asChild ? Slot.Root : "button";
+  const Comp = asChild ? Slot.Root : "button"
 
   return (
     <Comp
@@ -58,7 +58,7 @@ function Button({
       className={cn(buttonVariants({ variant, size, className }))}
       {...props}
     />
-  );
+  )
 }
 
-export { Button, buttonVariants };
+export { Button, buttonVariants }

--- a/frontend/src/lib/api/retrospective.ts
+++ b/frontend/src/lib/api/retrospective.ts
@@ -30,3 +30,10 @@ export async function getRetrospective(
   if (!response.ok) throw new Error("Failed to fetch retrospective");
   return response.json();
 }
+
+export async function deleteRetrospective(id: number): Promise<void> {
+  const response = await apiFetch(`/retrospectives/${id}`, {
+    method: "DELETE",
+  });
+  if (!response.ok) throw new Error("Failed to delete retrospective");
+}

--- a/frontend/src/router.tsx
+++ b/frontend/src/router.tsx
@@ -4,6 +4,7 @@ import Home from "@/routes/home";
 import Login from "@/routes/login";
 import Signup from "@/routes/signup";
 import NewRetrospective from "@/routes/retrospectives/new";
+import RetrospectiveDetail from "@/routes/retrospectives/detail";
 import EditRetrospective from "@/routes/retrospectives/edit";
 import {
   requireAuth,
@@ -25,6 +26,11 @@ export const router = createBrowserRouter([
         path: "retrospectives/new",
         loader: requireAuth,
         Component: NewRetrospective,
+      },
+      {
+        path: "retrospectives/:id",
+        loader: retrospectiveDetailLoader,
+        Component: RetrospectiveDetail,
       },
       {
         path: "retrospectives/:id/edit",

--- a/frontend/src/routes/home.tsx
+++ b/frontend/src/routes/home.tsx
@@ -5,6 +5,7 @@ import {
   CardHeader,
   CardTitle,
   CardDescription,
+  CardContent,
 } from "@/components/ui/card";
 import { Plus } from "lucide-react";
 import type { Retrospective } from "@/types/retrospective";
@@ -44,7 +45,7 @@ export default function Home() {
             <Card
               key={retro.id}
               className="cursor-pointer transition-shadow hover:shadow-md"
-              onClick={() => navigate(`/retrospectives/${retro.id}/edit`)}
+              onClick={() => navigate(`/retrospectives/${retro.id}`)}
             >
               <CardHeader>
                 <CardTitle className="text-lg">{retro.title}</CardTitle>
@@ -55,6 +56,13 @@ export default function Home() {
                   {new Date(retro.createdAt).toLocaleDateString("ja-JP")}
                 </p>
               </CardHeader>
+              <CardContent>
+                <div className="flex gap-3 text-xs">
+                  <span className="text-emerald-700">K: {retro.keepCount}</span>
+                  <span className="text-red-700">P: {retro.problemCount}</span>
+                  <span className="text-amber-700">T: {retro.tryCount}</span>
+                </div>
+              </CardContent>
             </Card>
           ))}
         </div>

--- a/frontend/src/routes/retrospectives/detail.tsx
+++ b/frontend/src/routes/retrospectives/detail.tsx
@@ -1,0 +1,114 @@
+import { useState, useCallback } from "react";
+import { useLoaderData, useNavigate } from "react-router";
+import { Button } from "@/components/ui/button";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from "@/components/ui/alert-dialog";
+import { ArrowLeft, Pencil, Trash2 } from "lucide-react";
+import { KptColumn } from "@/components/kpt-column";
+import { deleteRetrospective } from "@/lib/api/retrospective";
+import type {
+  RetrospectiveDetail as RetrospectiveDetailType,
+  KptItem,
+  KptType,
+} from "@/types/retrospective";
+
+export default function RetrospectiveDetail() {
+  const { retrospective } = useLoaderData<{
+    retrospective: RetrospectiveDetailType;
+  }>();
+  const navigate = useNavigate();
+  const [isDeleting, setIsDeleting] = useState(false);
+
+  const itemsByType = useCallback(
+    (type: KptType): KptItem[] =>
+      retrospective.kptItems
+        .filter((item) => item.type === type)
+        .sort((a, b) => a.sortOrder - b.sortOrder),
+    [retrospective.kptItems],
+  );
+
+  const handleDelete = async () => {
+    setIsDeleting(true);
+    try {
+      await deleteRetrospective(retrospective.id);
+      navigate("/");
+    } catch {
+      setIsDeleting(false);
+    }
+  };
+
+  return (
+    <div className="flex min-h-screen flex-col">
+      <header className="border-b bg-white px-6 py-4">
+        <div className="mx-auto flex max-w-7xl items-center gap-4">
+          <Button variant="ghost" size="sm" onClick={() => navigate("/")}>
+            <ArrowLeft className="mr-1 h-4 w-4" />
+            戻る
+          </Button>
+          <div className="flex-1">
+            <h1 className="text-xl font-bold">{retrospective.title}</h1>
+            {retrospective.description && (
+              <p className="text-sm text-muted-foreground">
+                {retrospective.description}
+              </p>
+            )}
+          </div>
+          <div className="flex gap-2">
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={() =>
+                navigate(`/retrospectives/${retrospective.id}/edit`)
+              }
+            >
+              <Pencil className="mr-1 h-4 w-4" />
+              編集
+            </Button>
+            <AlertDialog>
+              <AlertDialogTrigger asChild>
+                <Button variant="destructive" size="sm" disabled={isDeleting}>
+                  <Trash2 className="mr-1 h-4 w-4" />
+                  削除
+                </Button>
+              </AlertDialogTrigger>
+              <AlertDialogContent>
+                <AlertDialogHeader>
+                  <AlertDialogTitle>振り返りを削除しますか？</AlertDialogTitle>
+                  <AlertDialogDescription>
+                    「{retrospective.title}」を削除します。この操作は取り消せません。
+                  </AlertDialogDescription>
+                </AlertDialogHeader>
+                <AlertDialogFooter>
+                  <AlertDialogCancel>キャンセル</AlertDialogCancel>
+                  <AlertDialogAction
+                    onClick={handleDelete}
+                    disabled={isDeleting}
+                  >
+                    削除する
+                  </AlertDialogAction>
+                </AlertDialogFooter>
+              </AlertDialogContent>
+            </AlertDialog>
+          </div>
+        </div>
+      </header>
+
+      <main className="flex-1 p-6">
+        <div className="mx-auto grid max-w-7xl grid-cols-1 items-start gap-4 md:grid-cols-3">
+          <KptColumn type="KEEP" items={itemsByType("KEEP")} readOnly />
+          <KptColumn type="PROBLEM" items={itemsByType("PROBLEM")} readOnly />
+          <KptColumn type="TRY" items={itemsByType("TRY")} readOnly />
+        </div>
+      </main>
+    </div>
+  );
+}

--- a/frontend/src/routes/retrospectives/detail.tsx
+++ b/frontend/src/routes/retrospectives/detail.tsx
@@ -84,7 +84,8 @@ export default function RetrospectiveDetail() {
                 <AlertDialogHeader>
                   <AlertDialogTitle>振り返りを削除しますか？</AlertDialogTitle>
                   <AlertDialogDescription>
-                    「{retrospective.title}」を削除します。この操作は取り消せません。
+                    「{retrospective.title}
+                    」を削除します。この操作は取り消せません。
                   </AlertDialogDescription>
                 </AlertDialogHeader>
                 <AlertDialogFooter>

--- a/frontend/src/types/retrospective.ts
+++ b/frontend/src/types/retrospective.ts
@@ -13,6 +13,9 @@ export interface Retrospective {
   id: number;
   title: string;
   description: string | null;
+  keepCount: number;
+  problemCount: number;
+  tryCount: number;
   createdAt: string;
   updatedAt: string;
 }


### PR DESCRIPTION
## Summary
- 一覧ページのカードに KPT アイテム数サマリー（K: x / P: x / T: x）を表示
- 読み取り専用の詳細ページ（`/retrospectives/:id`）を新規作成（KPT 3カラム表示）
- 詳細ページから編集ページへの遷移ボタンを追加
- 確認ダイアログ付きの振り返り削除機能を実装
- バックエンド一覧 API レスポンスに `keepCount` / `problemCount` / `tryCount` を追加

## Test plan
- [x] `./gradlew test` — バックエンド全92テストパス
- [x] `pnpm build` — フロントエンドビルドエラーなし
- [x] 一覧ページで各カードに KPT カウントが表示される
- [x] カードクリックで詳細ページに遷移する
- [x] 詳細ページで KPT アイテムが読み取り専用で表示される（追加・編集・削除ボタン非表示）
- [x] 「編集」ボタンで編集ページに遷移する
- [x] 「削除」ボタンで確認ダイアログが表示され、削除後に一覧に戻る

Closes #9

🤖 Generated with [Claude Code](https://claude.com/claude-code)